### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
-ARG VERSION
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-powervs
 COPY . .
-
-RUN GOPROXY=off NO_DOCKER=1 GOARCH=ppc64le GOOS=linux VERSION=$VERSION make build
+# VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
+RUN unset VERSION \
+ && GOPROXY=off NO_DOCKER=1 GOARCH=ppc64le make build
 
 FROM --platform=ppc64le registry.access.redhat.com/ubi8/ubi:8.4
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-powervs/bin/machine-controller-manager /


### PR DESCRIPTION
Earlier VERSION argument passed explicitly to the make command because `git describe` was not generating a proper version in the format of semver because of no annotated tag present in the GH, with the recent creation of annotated tag now `git describe` does expose the right version in the format of semver, hence removing this workaround from the code which is not required anymore.

e.g:

```shell
$ git describe --always --abbrev=7                                                     
v0.0.1-3-gaecd477
```

One more nit: remove `GOOS=linux` because we are building these images mostly in the Linux OS,