### PR TITLE
build_root configuration

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.16


### PR DESCRIPTION
This is to enable the CI, added build_root_image configuration used for prow CI, more info: https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image