### PR TITLE
Rename IBMCLOUD_API_KEY to ibmcloud_api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note: this info is RH only, it needs to be backported every time the `README.md`
      namespace: openshift-machine-api
    type: Opaque
    data:
-     IBMCLOUD_API_KEY: FILLIN
+     ibmcloud_api_key: FILLIN
    ```
 
    You can use `examples/render-powervs-secrets.sh` script to generate the secret:

--- a/examples/addons.yaml
+++ b/examples/addons.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-machine-api
 type: Opaque
 data:
-  IBMCLOUD_API_KEY:
+  ibmcloud_api_key:

--- a/examples/render-powervs-secrets.sh
+++ b/examples/render-powervs-secrets.sh
@@ -14,5 +14,5 @@ fi
 
 x=$(echo -n "$IBMCLOUD_API_KEY" | base64)
 
-sed -e "s/IBMCLOUD_API_KEY:.*/IBMCLOUD_API_KEY: $x/" \
+sed -e "s/ibmcloud_api_key:.*/ibmcloud_api_key: $x/" \
     "$1"

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -39,7 +39,7 @@ func stubPowerVSCredentialsSecret(name string) *corev1.Secret {
 			Namespace: defaultNamespace,
 		},
 		Data: map[string][]byte{
-			"IBMCLOUD_API_KEY": []byte("Kl9k1elFgPb_QgEDF0d5iNHMOFa--YX6JWLpi0XkWn"),
+			"ibmcloud_api_key": []byte("Kl9k1elFgPb_QgEDF0d5iNHMOFa--YX6JWLpi0XkWn"),
 		},
 	}
 }

--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -66,8 +66,8 @@ type PowerVSClientBuilderFuncType func(client client.Client, secretName, namespa
 
 func apiKeyFromSecret(secret *corev1.Secret) (apiKey string, err error) {
 	switch {
-	case len(secret.Data["IBMCLOUD_API_KEY"]) > 0:
-		apiKey = string(secret.Data["IBMCLOUD_API_KEY"])
+	case len(secret.Data["ibmcloud_api_key"]) > 0:
+		apiKey = string(secret.Data["ibmcloud_api_key"])
 	default:
 		return "", fmt.Errorf("invalid secret for powervs credentials")
 	}


### PR DESCRIPTION
This is to keep sync with ibmcloud mapi and cloud-credential-operator to reuse the code.