### PR TITLE
Rename the secret name for the credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note: this info is RH only, it needs to be backported every time the `README.md`
    apiVersion: v1
    kind: Secret
    metadata:
-     name: powervs-credentials-secret
+     name: powervs-credentials
      namespace: openshift-machine-api
    type: Opaque
    data:

--- a/examples/addons.yaml
+++ b/examples/addons.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: powervs-credentials-secret
+  name: powervs-credentials
   namespace: openshift-machine-api
 type: Opaque
 data:

--- a/examples/machine-set.yaml
+++ b/examples/machine-set.yaml
@@ -27,7 +27,7 @@ spec:
           userDataSecret:
             name: worker-user-data
           credentialsSecret:
-            name: powervs-credentials-secret
+            name: powervs-credentials
           sysType: s922
           procType: shared
           processors: 0.25

--- a/examples/machine-with-user-data.yaml
+++ b/examples/machine-with-user-data.yaml
@@ -16,7 +16,7 @@ spec:
       userDataSecret:
         name: worker-user-data
       credentialsSecret:
-        name: powervs-credentials-secret
+        name: powervs-credentials
       sysType: s922
       procType: shared
       processors: 0.25

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultNamespace      = "default"
-	credentialsSecretName = "powervs-credentials-secret"
+	credentialsSecretName = "powervs-credentials"
 	userDataSecretName    = "powervs-actuator-user-data-secret"
 	nameLength            = 5
 )

--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -37,7 +37,7 @@ const (
 	//DefaultCredentialNamespace is the default namespace used to create a client object
 	DefaultCredentialNamespace = "openshift-machine-api"
 	//DefaultCredentialSecret is the credential secret name used by node update controller to fetch API key
-	DefaultCredentialSecret = "powervs-credentials-secret"
+	DefaultCredentialSecret = "powervs-credentials"
 
 	//InstanceStateNameShutoff is indicates the shutoff state of Power VS instance
 	InstanceStateNameShutoff = "SHUTOFF"


### PR DESCRIPTION
This change is to keep the naming convention in sync with other providers.

ref: secretref's from https://github.com/openshift/machine-api-operator/blob/master/install/0000_30_machine-api-operator_00_credentials-request.yaml