### PR TITLE
Rename providerid to match the patter with vpc provider

### DIFF
--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -57,7 +57,7 @@ var (
 
 //FormatProviderID formats and returns the provided instanceID
 func FormatProviderID(instanceID string) string {
-	return fmt.Sprintf("powervs:///%s", instanceID)
+	return fmt.Sprintf("ibmpowervs:///%s", instanceID)
 }
 
 //PowerVSClientBuilderFuncType is function type for building the Power VS client


### PR DESCRIPTION
This PR is to keep in sync with ibm vpc provider naming convention.