### PR TITLE
Populate the NodeInternalDNS for the machine

### DIFF
--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -171,6 +171,11 @@ func (s *machineScope) setProviderStatus(instance *models.PVMInstance, condition
 					})
 			}
 		}
+		networkAddresses = append(networkAddresses,
+			corev1.NodeAddress{
+				Type:    corev1.NodeInternalDNS,
+				Address: *instance.ServerName,
+			})
 	}
 	klog.Infof("%s: finished calculating PowerVS status", s.machine.Name)
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -99,6 +99,7 @@ func stubGetInstance() *models.PVMInstance {
 	return &models.PVMInstance{
 		PvmInstanceID: &dummyInstanceID,
 		Status:        &status,
+		ServerName:    core.StringPtr("instance"),
 	}
 }
 


### PR DESCRIPTION
This is required for the https://github.com/openshift/cluster-machine-approver/tree/master project to compare the csr certificates with the machines DNS qualified name, hence this change will add that additional required change to the machine resource.

x-ref: https://issues.redhat.com/browse/MULTIARCH-1598